### PR TITLE
Fixed inventory entry params

### DIFF
--- a/IISWithBindings/Jobs/Inventory.cs
+++ b/IISWithBindings/Jobs/Inventory.cs
@@ -83,14 +83,25 @@ namespace Keyfactor.Extensions.Orchestrator.IISWithBinding.Jobs
                             if (foundCert == null)
                                 continue;
 
+                            var siteSettingsDict = new Dictionary<string, object>
+                            {
+                                { "Site Name", binding.Properties["Name"]?.Value },
+                                { "Port", binding.Properties["Bindings"]?.Value.ToString()?.Split(':')[1] },
+                                { "IP Address", binding.Properties["Bindings"]?.Value.ToString()?.Split(':')[0] },
+                                { "Host Name", binding.Properties["Bindings"]?.Value.ToString()?.Split(':')[2] },
+                                { "Sni Flag", binding.Properties["sniFlg"]?.Value },
+                                { "Protocol", binding.Properties["Protocol"]?.Value }
+                            };
+
                             inventoryItems.Add(
                                 new CurrentInventoryItem
                                 {
-                                    Certificates = new[] {foundCert.CertificateData},
+                                    Certificates = new[] { foundCert.CertificateData },
                                     Alias = thumbPrint,
                                     PrivateKeyEntry = foundCert.HasPrivateKey,
                                     UseChainLevel = false,
-                                    ItemStatus = OrchestratorInventoryItemStatus.Unknown
+                                    ItemStatus = OrchestratorInventoryItemStatus.Unknown,
+                                    Parameters = siteSettingsDict
                                 }
                             );
                         }


### PR DESCRIPTION
Fix for where the inventory process was not correctly using the entry params to set binding information.