### PR TITLE
Fixed Null entry errors when Hostname and SAN is empty.

### DIFF
--- a/IISU/IISManager.cs
+++ b/IISU/IISManager.cs
@@ -64,7 +64,7 @@ namespace Keyfactor.Extensions.Orchestrator.IISU
             {
                 SiteName = config.JobProperties["SiteName"].ToString();
                 Port = config.JobProperties["Port"].ToString();
-                HostName = config.JobProperties["HostName"].ToString();
+                HostName = config.JobProperties["HostName"]?.ToString();
                 Protocol = config.JobProperties["Protocol"].ToString();
                 SniFlag = config.JobProperties["SniFlag"].ToString()?.Substring(0, 1);
                 IpAddress = config.JobProperties["IPAddress"].ToString();

--- a/IISU/Jobs/ReEnrollment.cs
+++ b/IISU/Jobs/ReEnrollment.cs
@@ -118,12 +118,15 @@ namespace Keyfactor.Extensions.Orchestrator.IISU.Jobs
                 ps.AddScript($"Add-Content $infFilename 'KeyLength={keySize}'");
                 ps.AddScript($"Add-Content $infFilename 'KeySpec = 0'");
 
-                ps.AddScript($"Add-Content $infFilename '[Extensions]'");
-                ps.AddScript(@"Add-Content $infFilename '2.5.29.17 = ""{text}""'");
-
-                foreach (string s in SAN.ToString().Split("&"))
+                if(SAN != null)
                 {
-                    ps.AddScript($"Add-Content $infFilename '_continue_ = \"{s + "&"}\"'");
+                    ps.AddScript($"Add-Content $infFilename '[Extensions]'");
+                    ps.AddScript(@"Add-Content $infFilename '2.5.29.17 = ""{text}""'");
+
+                    foreach (string s in SAN.ToString().Split("&"))
+                    {
+                        ps.AddScript($"Add-Content $infFilename '_continue_ = \"{s + "&"}\"'");
+                    }
                 }
 
                 // Execute the -new command


### PR DESCRIPTION
Fixed the problem when Hostname or SAN was not included, the orchestrator would fail with a NULL error.
Please be aware that if the SAN is not included but the template requires it, the reenrollment will fail gracefully with an error and retry n-times before it stops.  You will then be prompted to include a valid SAN.