### PR TITLE
ab#61690 fix WinRM parameter spelling for WinCert store type migration script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.4.4
+* Fix an issue with WinRM parameters when migrating Legacy IIS Stores to the WinCert type
+
 2.4.3
 * Adding Legacy IIS Migration scripting and Readme guide
 

--- a/Migration-Scripts/Legacy-IIS/UpgradeIISPersonalToWinCert.sql
+++ b/Migration-Scripts/Legacy-IIS/UpgradeIISPersonalToWinCert.sql
@@ -204,7 +204,7 @@ BEGIN TRY
 		@win_cert_store_type_id,
 		[psd].[StoreApproved],
 		0,
-		'{"WinRm Protocol":"'+@winrm_protocol+'","WinRm Port":"'+CONVERT(NVARCHAR(10),@winrm_port)+'","spnwithport":"'+@spnwithport+'","ServerUsername":"'+CONVERT(NVARCHAR(36),NEWID())+'","ServerPassword":"'+CONVERT(NVARCHAR(36),NEWID())+'","ServerUseSsl":"true"}',
+		'{"WinRM Protocol":"'+@winrm_protocol+'","WinRM Port":"'+CONVERT(NVARCHAR(10),@winrm_port)+'","spnwithport":"'+@spnwithport+'","ServerUsername":"'+CONVERT(NVARCHAR(36),NEWID())+'","ServerPassword":"'+CONVERT(NVARCHAR(36),NEWID())+'","ServerUseSsl":"true"}',
 		[psd].[AgentId]
 	FROM @iis_store_data [psd];
 

--- a/Migration-Scripts/Legacy-IIS/UpgradeIISRevokedAndRootsToWinCert.sql
+++ b/Migration-Scripts/Legacy-IIS/UpgradeIISRevokedAndRootsToWinCert.sql
@@ -159,7 +159,7 @@ BEGIN TRY
 		@win_cert_store_type_id,
 		[psd].[StoreApproved],
 		0,
-		''{"WinRm Protocol":"''+@winrm_protocol+''","WinRm Port":"''+CONVERT(NVARCHAR(10),@winrm_port)+''","spnwithport":"''+@spnwithport+''","ServerUsername":"''+CONVERT(NVARCHAR(36),NEWID())+''","ServerPassword":"''+CONVERT(NVARCHAR(36),NEWID())+''","ServerUseSsl":"true"}'',
+		''{"WinRM Protocol":"''+@winrm_protocol+''","WinRM Port":"''+CONVERT(NVARCHAR(10),@winrm_port)+''","spnwithport":"''+@spnwithport+''","ServerUsername":"''+CONVERT(NVARCHAR(36),NEWID())+''","ServerPassword":"''+CONVERT(NVARCHAR(36),NEWID())+''","ServerUseSsl":"true"}'',
 		[psd].[AgentId]
 	FROM @iis_store_data [psd];'
 


### PR DESCRIPTION
WinRM parameters in WinCert are spelt "WinRM" while IISU are spelt "WinRm". the scripts need to match the spelling to have the parameters set correctly