### PR TITLE
ab#62371 delete records from additional dependent tables

### DIFF
--- a/Migration-Scripts/Legacy-IIS/DeleteIISStores.sql
+++ b/Migration-Scripts/Legacy-IIS/DeleteIISStores.sql
@@ -27,27 +27,37 @@ BEGIN TRY
 		INNER JOIN [cms_agents].[CertStores] [cs] ON [csii].[CertStoreId] = [cs].[Id]
 		INNER JOIN @IISStoreTypeIds [sti] ON [sti].[Id] = [cs].[CertStoreType];
 
-	DELETE [cs]
-	FROM [cms_agents].[CertStores] [cs]
-		INNER JOIN @IISStoreTypeIds [st] ON [cs].[CertStoreType] = [st].[Id];
-
-	DELETE [csc]
-	FROM [cms_agents].[CertStoreContainers] [csc]
-		INNER JOIN @IISStoreTypeIds [st] ON [csc].[CertStoreType] = [st].[Id];
-
-	DELETE [csij]
-	FROM [cms_agents].[CertStoreInventoryJobs] [csij]
-		INNER JOIN [cms_agents].[AgentSchedules] [as] ON [csij].[JobId] = [as].[JobId]
+	DELETE [csmj]
+	FROM [cms_agents].[CertStoreManagementJobs] [csmj]
+		INNER JOIN [cms_agents].[AgentSchedules] [as] ON [csmj].[JobId] = [as].[JobId]
 		INNER JOIN @IISJobTypeIds [jti] ON [jti].[Id] = [as].[JobTypeId];
+
+	DELETE [csms]
+	FROM [dbo].[CertStoreManagementStaging] [csms]
+		INNER JOIN [cms_agents].[CertStores] [cs] ON [csms].[CertStoreId] = [cs].[Id]
+		INNER JOIN @IISStoreTypeIds [sti] ON [sti].[Id] = [cs].[CertStoreType];
+
+	DELETE [csmjs]
+	FROM [cms_agents].[CertStoreManagementJobStaging] [csmjs]
+		INNER JOIN [cms_agents].[CertStores] [cs] ON [csmjs].[StoreId] = [cs].[Id]
+		INNER JOIN @IISStoreTypeIds [st] ON [st].[Id] = [cs].[CertStoreType];
 
 	DELETE [csrj]
 	FROM [cms_agents].[CertStoreReenrollmentJobs] [csrj]
 		INNER JOIN [cms_agents].[AgentSchedules] [as] ON [csrj].[JobId] = [as].[JobId]
 		INNER JOIN @IISJobTypeIds [jti] ON [jti].[Id] = [as].[JobTypeId];
 
-	DELETE [csmj]
-	FROM [cms_agents].[CertStoreManagementJobs] [csmj]
-		INNER JOIN [cms_agents].[AgentSchedules] [as] ON [csmj].[JobId] = [as].[JobId]
+	DELETE [cs]
+	FROM [cms_agents].[CertStores] [cs]
+		INNER JOIN @IISStoreTypeIds [st] ON [cs].[CertStoreType] = [st].[Id];
+
+	DELETE [csc]
+	FROM [cms_agents].[CertStoreContainers] [csc]
+		INNER JOIN @IISStoreTypeIds [st] ON [csc].[CertStoreType] = [st].[Id];	
+
+	DELETE [csij]
+	FROM [cms_agents].[CertStoreInventoryJobs] [csij]
+		INNER JOIN [cms_agents].[AgentSchedules] [as] ON [csij].[JobId] = [as].[JobId]
 		INNER JOIN @IISJobTypeIds [jti] ON [jti].[Id] = [as].[JobTypeId];
 
 	DELETE [as]
@@ -56,11 +66,19 @@ BEGIN TRY
 
 	DELETE [cstp]
 	FROM [cms_agents].[CertStoreTypeProperties] [cstp]
-		INNER JOIN @IISStoreTypeIds [st] ON [cstp].[StoreTypeId] = [st].[id];
+		INNER JOIN @IISStoreTypeIds [st] ON [cstp].[StoreTypeId] = [st].[Id];
+
+	DELETE [cstep]
+	FROM [cms_agents].[CertStoreTypeEntryParameters] [cstep]
+		INNER JOIN @IISStoreTypeIds [st] ON [cstep].[StoreTypeId] = [st].[Id];
 
 	DELETE [cst]
 	FROM [cms_agents].[CertStoreTypes] [cst]
 		INNER JOIN @IISStoreTypeIds [st] ON [cst].[StoreType] = [st].[id];
+
+	DELETE [arg]
+	FROM [cms_agents].[AgentRegistrationGroups] [arg]
+		INNER JOIN @IISJobTypeIds [jt] ON [arg].[JobTypeId] = [jt].[Id];
 
 	DELETE [ars]
 	FROM [cms_agents].[AgentRegistrationSettings] [ars]
@@ -69,6 +87,10 @@ BEGIN TRY
 	DELETE [ac]
 	FROM [cms_agents].[AgentCapabilities] [ac]
 		INNER JOIN @IISJobTypeIds [jt] ON [ac].[JobTypeId] = [jt].[Id];
+
+	DELETE [jtf]
+	FROM [cms_agents].[JobTypeFields] [jtf]
+		INNER JOIN @IISJobTypeIds [jt] ON [jtf].[JobTypeId] = [jt].[Id];
 
 	DELETE [jt]
 	FROM [cms_agents].[JobTypes] [jt]


### PR DESCRIPTION
fix to delete script for Legacy IIS migration to remove additional records in dependent tables when removing cert store type