### PR TITLE
64674 remove old certs on renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.6.3
 * Fixed reenrollment job when RDN Components contained escaped commas
+* Updated renewal job for IIS Certs to delete the old cert if not bound or used by other web sites.
 
 2.6.2
 * Fixed error when attempting to connect to remote computer using UO service account

--- a/IISU/ImplementedStoreTypes/WinIIS/Inventory.cs
+++ b/IISU/ImplementedStoreTypes/WinIIS/Inventory.cs
@@ -95,7 +95,7 @@ namespace Keyfactor.Extensions.Orchestrator.WindowsCertStore.IISU
                     {
                         Result = OrchestratorJobStatusJobResult.Success,
                         JobHistoryId = jobConfiguration.JobHistoryId,
-                        FailureMessage = ""
+                        FailureMessage = $"Inventory completed returning {inventoryItems.Count} Items."
                     };
                 }
 

--- a/IISU/PowerShellScripts/WinCertScripts.ps1
+++ b/IISU/PowerShellScripts/WinCertScripts.ps1
@@ -818,7 +818,7 @@ function Remove-KFIISCertificateIfUnused {
 
         if ($bindings.Count -gt 0) {
             Write-Warning "The certificate with thumbprint $thumbprint is still used by the following bindings:"
-            $bindings | Format-Table -AutoSize
+            $bindings | Format-Table -AutoSize | Out-String | Write-Warning
             return
         }
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ The Windows Certificate Universal Orchestrator extension implements 3 Certificat
 This integration is compatible with Keyfactor Universal Orchestrator version 10.1 and later.
 
 ## Support
-The Windows Certificate Universal Orchestrator extension If you have a support issue, please open a support ticket by either contacting your Keyfactor representative or via the Keyfactor Support Portal at https://support.keyfactor.com.
+The Windows Certificate Universal Orchestrator extension is supported by Keyfactor. If you require support for any issues or have feature request, please open a support ticket by either contacting your Keyfactor representative or via the Keyfactor Support Portal at https://support.keyfactor.com.
 
-> To report a problem or suggest a new feature, use the **[Issues](../../issues)** tab. If you want to contribute actual bug fixes or proposed enhancements, use the **[Pull requests](../../pulls)** tab.
+> If you want to contribute bug fixes or additional enhancements, use the **[Pull requests](../../pulls)** tab.
 
 ## Requirements & Prerequisites
 
@@ -134,6 +134,26 @@ For customers wishing to use something other than the local administrator accoun
     -	Execute certreq commands.
     -	Access any Cryptographic Service Provider (CSP) referenced in re-enrollment jobs.
     -	Read and Write values in the registry (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server) when performing SQL Server certificate binding.
+
+### Using Crypto Service Providers (CSP)
+When adding or reenrolling certificates, you may specify an optional CSP to be used when generating and storing the private keys.  This value would typically be specified when leveraging a Hardware Security Module (HSM). The specified cryptographic provider must be available on the target server being managed. 
+
+The list of installed cryptographic providers can be obtained by running the PowerShell command on the target server:
+
+     certutil -csplist
+
+When performing a ReEnrollment or On Device Key Generation (ODKG) job, if no CSP is specified, a default value of 'Microsoft Strong Cryptographic Provider' will be used.  
+
+When performing an Add job, if no CSP is specified, the machine's default CSP will be used, in most cases this could be the 'Microsoft Enhanced Cryptographic Provider v1.0' provider.
+
+Each CSP only supports certain key types and algorithms.
+
+Below is a brief summary of the CSPs and their support for RSA and ECC algorithms:
+|CSP Name|Supports RSA?|Supports ECC?|
+|---|---|---|
+|Microsoft RSA SChannel Cryptographic Provider	|✅|❌|
+|Microsoft Software Key Storage Provider	    |✅|✅|
+|Microsoft Enhanced Cryptographic Provider	    |✅|❌|
 
 
 ## Certificate Store Types
@@ -257,7 +277,7 @@ the Keyfactor Command Portal
 
    | Name | Display Name | Description | Type | Default Value | Entry has a private key | Adding an entry | Removing an entry | Reenrolling an entry |
    | ---- | ------------ | ---- | ------------- | ----------------------- | ---------------- | ----------------- | ------------------- | ----------- |
-   | ProviderName | Crypto Provider Name | Name of the Windows cryptographic provider to use during reenrollment jobs when generating and storing the private keys. If not specified, defaults to 'Microsoft Strong Cryptographic Provider'. This value would typically be specified when leveraging a Hardware Security Module (HSM). The specified cryptographic provider must be available on the target server being managed. The list of installed cryptographic providers can be obtained by running 'certutil -csplist' on the target Server. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
+   | ProviderName | Crypto Provider Name | Name of the Windows cryptographic service provider to use when generating and storing private keys. For more information, refer to the section 'Using Crypto Service Providers' | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | SAN | SAN | String value specifying the Subject Alternative Name (SAN) to be used when performing reenrollment jobs. Format as a list of <san_type>=<san_value> entries separated by ampersands; Example: 'dns=www.example.com&dns=www.example2.com' for multiple SANs. Can be made optional if RFC 2818 is disabled on the CA. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | ✅ Checked |
 
    The Entry Parameters tab should look like this:
@@ -392,7 +412,7 @@ the Keyfactor Command Portal
    | SiteName | IIS Site Name | String value specifying the name of the IIS web site to bind the certificate to. Example: 'Default Web Site' or any custom site name such as 'MyWebsite'. | String | Default Web Site | 🔲 Unchecked | ✅ Checked | ✅ Checked | ✅ Checked |
    | SniFlag | SSL Flags | A 128-Bit Flag that determines what type of SSL settings you wish to use.  The default is 0, meaning No SNI.  For more information, check IIS documentation for the appropriate bit setting.) | String | 0 | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | Protocol | Protocol | Multiple choice value specifying the protocol to bind to. Example: 'https' for secure communication. | MultipleChoice | https | 🔲 Unchecked | ✅ Checked | ✅ Checked | ✅ Checked |
-   | ProviderName | Crypto Provider Name | Name of the Windows cryptographic provider to use during reenrollment jobs when generating and storing the private keys. If not specified, defaults to 'Microsoft Strong Cryptographic Provider'. This value would typically be specified when leveraging a Hardware Security Module (HSM). The specified cryptographic provider must be available on the target server being managed. The list of installed cryptographic providers can be obtained by running 'certutil -csplist' on the target Server. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
+   | ProviderName | Crypto Provider Name | Name of the Windows cryptographic service provider to use when generating and storing private keys. For more information, refer to the section 'Using Crypto Service Providers' | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | SAN | SAN | String value specifying the Subject Alternative Name (SAN) to be used when performing reenrollment jobs. Format as a list of <san_type>=<san_value> entries separated by ampersands; Example: 'dns=www.example.com&dns=www.example2.com' for multiple SANs. Can be made optional if RFC 2818 is disabled on the CA. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | ✅ Checked |
 
    The Entry Parameters tab should look like this:
@@ -515,7 +535,7 @@ the Keyfactor Command Portal
    | Name | Display Name | Description | Type | Default Value | Entry has a private key | Adding an entry | Removing an entry | Reenrolling an entry |
    | ---- | ------------ | ---- | ------------- | ----------------------- | ---------------- | ----------------- | ------------------- | ----------- |
    | InstanceName | Instance Name | String value specifying the SQL Server instance name to bind the certificate to. Example: 'MSSQLServer' for the default instance or 'Instance1' for a named instance. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
-   | ProviderName | Crypto Provider Name | Optional string value specifying the name of the Windows cryptographic provider to use during reenrollment jobs when generating and storing private keys. Example: 'Microsoft Strong Cryptographic Provider'. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
+   | ProviderName | Crypto Provider Name | Name of the Windows cryptographic service provider to use when generating and storing private keys. For more information, refer to the section 'Using Crypto Service Providers' | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | SAN | SAN | String value specifying the Subject Alternative Name (SAN) to be used when performing reenrollment jobs. Format as a list of <san_type>=<san_value> entries separated by ampersands; Example: 'dns=www.example.com&dns=www.example2.com' for multiple SANs. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | ✅ Checked |
 
    The Entry Parameters tab should look like this:

--- a/docsource/content.md
+++ b/docsource/content.md
@@ -82,6 +82,26 @@ For customers wishing to use something other than the local administrator accoun
     -	Access any Cryptographic Service Provider (CSP) referenced in re-enrollment jobs.
     -	Read and Write values in the registry (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server) when performing SQL Server certificate binding.
 
+### Using Crypto Service Providers (CSP)
+When adding or reenrolling certificates, you may specify an optional CSP to be used when generating and storing the private keys.  This value would typically be specified when leveraging a Hardware Security Module (HSM). The specified cryptographic provider must be available on the target server being managed. 
+
+The list of installed cryptographic providers can be obtained by running the PowerShell command on the target server:
+
+     certutil -csplist
+
+When performing a ReEnrollment or On Device Key Generation (ODKG) job, if no CSP is specified, a default value of 'Microsoft Strong Cryptographic Provider' will be used.  
+
+When performing an Add job, if no CSP is specified, the machine's default CSP will be used, in most cases this could be the 'Microsoft Enhanced Cryptographic Provider v1.0' provider.
+
+Each CSP only supports certain key types and algorithms.
+
+Below is a brief summary of the CSPs and their support for RSA and ECC algorithms:
+|CSP Name|Supports RSA?|Supports ECC?|
+|---|---|---|
+|Microsoft RSA SChannel Cryptographic Provider	|✅|❌|
+|Microsoft Software Key Storage Provider	    |✅|✅|
+|Microsoft Enhanced Cryptographic Provider	    |✅|❌|
+
 ## Client Machine Instructions
 Prior to version 2.6, this extension would only run in the Windows environment.  Version 2.6 and greater is capable of running on Linux, however, only the SSH protocol is supported.
 

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -115,7 +115,7 @@
                             "DependsOn": "",
                             "DefaultValue": "",
                             "Options": "",
-                            "Description": "Name of the Windows cryptographic provider to use during reenrollment jobs when generating and storing the private keys. If not specified, defaults to 'Microsoft Strong Cryptographic Provider'. This value would typically be specified when leveraging a Hardware Security Module (HSM). The specified cryptographic provider must be available on the target server being managed. The list of installed cryptographic providers can be obtained by running 'certutil -csplist' on the target Server."
+                            "Description": "Name of the Windows cryptographic service provider to use when generating and storing private keys. For more information, refer to the section 'Using Crypto Service Providers'"
                         },
                         {
                             "Name": "SAN",
@@ -306,21 +306,21 @@
                             "Options": "https,http",
                             "Description": "Multiple choice value specifying the protocol to bind to. Example: 'https' for secure communication."
                         },
-                        {
-                            "Name": "ProviderName",
-                            "DisplayName": "Crypto Provider Name",
-                            "Type": "String",
-                            "RequiredWhen": {
-                                "HasPrivateKey": false,
-                                "OnAdd": false,
-                                "OnRemove": false,
-                                "OnReenrollment": false
-                            },
-                            "DependsOn": "",
-                            "DefaultValue": "",
-                            "Options": "",
-                            "Description": "Name of the Windows cryptographic provider to use during reenrollment jobs when generating and storing the private keys. If not specified, defaults to 'Microsoft Strong Cryptographic Provider'. This value would typically be specified when leveraging a Hardware Security Module (HSM). The specified cryptographic provider must be available on the target server being managed. The list of installed cryptographic providers can be obtained by running 'certutil -csplist' on the target Server."
+                      {
+                        "Name": "ProviderName",
+                        "DisplayName": "Crypto Provider Name",
+                        "Type": "String",
+                        "RequiredWhen": {
+                          "HasPrivateKey": false,
+                          "OnAdd": false,
+                          "OnRemove": false,
+                          "OnReenrollment": false
                         },
+                        "DependsOn": "",
+                        "DefaultValue": "",
+                        "Options": "",
+                        "Description": "Name of the Windows cryptographic service provider to use when generating and storing private keys. For more information, refer to the section 'Using Crypto Service Providers'"
+                      },
                         {
                             "Name": "SAN",
                             "DisplayName": "SAN",
@@ -441,21 +441,21 @@
                             },
                             "Description": "String value specifying the SQL Server instance name to bind the certificate to. Example: 'MSSQLServer' for the default instance or 'Instance1' for a named instance."
                         },
-                        {
-                            "Name": "ProviderName",
-                            "DisplayName": "Crypto Provider Name",
-                            "Type": "String",
-                            "RequiredWhen": {
-                                "HasPrivateKey": false,
-                                "OnAdd": false,
-                                "OnRemove": false,
-                                "OnReenrollment": false
-                            },
-                            "DependsOn": "",
-                            "DefaultValue": "",
-                            "Options": "",
-                            "Description": "Optional string value specifying the name of the Windows cryptographic provider to use during reenrollment jobs when generating and storing private keys. Example: 'Microsoft Strong Cryptographic Provider'."
+                      {
+                        "Name": "ProviderName",
+                        "DisplayName": "Crypto Provider Name",
+                        "Type": "String",
+                        "RequiredWhen": {
+                          "HasPrivateKey": false,
+                          "OnAdd": false,
+                          "OnRemove": false,
+                          "OnReenrollment": false
                         },
+                        "DependsOn": "",
+                        "DefaultValue": "",
+                        "Options": "",
+                        "Description": "Name of the Windows cryptographic service provider to use when generating and storing private keys. For more information, refer to the section 'Using Crypto Service Providers'"
+                      },
                         {
                             "Name": "SAN",
                             "DisplayName": "SAN",


### PR DESCRIPTION
Modified logic for IISU certs when a renewal job is performed.  Once the certificate has been renewed, the previous certificate is verified no to be bound or in use with other web sites.  If not used, the certificate will be removed from the certificate store.