### PR TITLE
IISU: fixed a null object reference bug with the legacy SANs resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+3.0.2
+* Fixed a null object reference bug when resolving SANs via the Entry Parameter. 
+
 3.0.1
 * Fixed an issues when renewing ECC Certificates 
 

--- a/IISU/ClientPSCertStoreReEnrollment.cs
+++ b/IISU/ClientPSCertStoreReEnrollment.cs
@@ -399,7 +399,7 @@ namespace Keyfactor.Extensions.Orchestrator.WindowsCertStore
             }
             else if (config.JobProperties != null &&
                 config.JobProperties.TryGetValue("SAN", out object legacySanValue) &&
-                !string.IsNullOrWhiteSpace(legacySanValue.ToString()))
+                    (legacySanValue is not null && !string.IsNullOrWhiteSpace(legacySanValue.ToString())))
             {
                 sanValue = legacySanValue.ToString().Trim();
                 sourceUsed = "config.JobProperties[\"SAN\"] (legacy)";

--- a/WindowsCertStore.UnitTests/SANsUnitTests.cs
+++ b/WindowsCertStore.UnitTests/SANsUnitTests.cs
@@ -59,15 +59,18 @@ namespace WindowsCertStore.UnitTests
             Assert.DoesNotContain("legacy.example.com", result); // ensure legacy ignored
         }
 
-        [Fact]
-        public void ResolveSanString_UsesLegacySAN_WhenConfigSANsMissing()
+        [Theory]
+        [InlineData("dns=legacy.example.com&dns=old.example.com")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ResolveSanString_UsesLegacySAN_WhenConfigSANsMissing(string legacySan)
         {
             // Arrange
             var config = new ReenrollmentJobConfiguration
             {
                 JobProperties = new Dictionary<string, object>
                 {
-                    { "SAN", "dns=legacy.example.com&dns=old.example.com" }
+                    { "SAN", legacySan }
                 },
                 SANs = new Dictionary<string, string[]>()
             };


### PR DESCRIPTION
#### Summary
Fixed a object null exception bug in the reenrollment SANs resolver logic.