### PR TITLE
Bump package to resolve CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+3.0.3
+* Updated the PowerShell SDK to 7.4.17 to address a vulnerability in the System.Security.Cryptography.XML package.
+
 3.0.2
 * Fixed SQL service restart behavior: previously the extension could stop multiple SQL services and fail to start all of them. It now restarts only the SQL service associated with the certificate being renewed.
 

--- a/IISU/WindowsCertStore.csproj
+++ b/IISU/WindowsCertStore.csproj
@@ -36,7 +36,7 @@
 		<PackageReference Include="Keyfactor.Orchestrators.Common" Version="3.2.0" />
 		<PackageReference Include="Keyfactor.Orchestrators.IOrchestratorJobExtensions" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-		<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.13" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.17" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageReference Include="runtime.linux-arm64.runtime.native.System.IO.Ports" Version="9.0.5" />
 		<PackageReference Include="runtime.osx-arm64.runtime.native.System.IO.Ports" Version="9.0.5" />
 		<PackageReference Include="System.Formats.Asn1" Version="8.0.2" Condition="'$(TargetFramework)' == 'net6.0'" />


### PR DESCRIPTION
Updated the PowerShell SDK to 7.4.17 to address a vulnerability in the System.Security.Cryptography.XML package